### PR TITLE
Fix hang if words.length == optimum_length

### DIFF
--- a/src/pubvis.js
+++ b/src/pubvis.js
@@ -2409,7 +2409,7 @@ PUBVIS = function () {
 
 
                 //check if the length of the given array exceeds the given optimum size
-                if (words.length >= optimum_length) {
+                if (words.length > optimum_length) {
                     optimum_size = words[optimum_length].size;
 
                     //look downward if to the element where the size get smaller


### PR DESCRIPTION
If ``words.length`` is equal to ``optimum_length``, then ``words[optimum_length]`` is undefined, and PubViz hangs whilst displaying the 'Loading...' message (logging "TypeError: undefined is not an object (evaluating 'words[optimum_length].size'" to the console).